### PR TITLE
Fix the case where src is still not having a value

### DIFF
--- a/src/pdf-viewer/pdf-viewer.component.ts
+++ b/src/pdf-viewer/pdf-viewer.component.ts
@@ -52,7 +52,7 @@ export class PdfViewerComponent extends OnInit {
   set src(_src) {
     this._src = _src;
 
-    if (this.isInitialised) {
+    if (this.isInitialised && this._src) {
       this.main();
     }
   }
@@ -143,16 +143,18 @@ export class PdfViewerComponent extends OnInit {
   }
 
   private loadPDF(src) {
-    (<any>window).PDFJS.getDocument(src).then((pdf: any) => {
-      this._pdf = pdf;
-      this.lastLoaded = src;
+    if (src) {
+        (<any>window).PDFJS.getDocument(src).then((pdf: any) => {
+          this._pdf = pdf;
+          this.lastLoaded = src;
 
-      if (this.afterLoadComplete && typeof this.afterLoadComplete === 'function') {
-        this.afterLoadComplete(pdf);
-      }
+          if (this.afterLoadComplete && typeof this.afterLoadComplete === 'function') {
+            this.afterLoadComplete(pdf);
+          }
 
-      this.onRender();
-    });
+          this.onRender();
+        });
+    }
   }
 
   private onRender() {


### PR DESCRIPTION
Hello,

I am suggesting small but valuable change. It fixes a crash of the pdf-viewer when it is evaluated as a component within a template of another component, who has not been yet fully initialized. In such case the "src" value may not be yet defined, but in the current code loadPDF is called and it crashes and never being executed again. This small patch is trying to avoid this and I hope it will be accepted