### PR TITLE
Create stacking context. fix #39 #43

### DIFF
--- a/src/pdf-viewer/pdf-viewer.component.ts
+++ b/src/pdf-viewer/pdf-viewer.component.ts
@@ -16,6 +16,7 @@ import 'pdfjs-dist/build/pdf.combined';
 
 :host >>> .ng2-pdf-viewer-container > div {
   position: relative;
+  z-index: 0;
 }
 
 :host >>> .textLayer {


### PR DESCRIPTION
When text is rendered canvas has a z-index of 1 to be kept under the text.
But because there is no stacking context anywhere inside `<pdf-viewer>` to encapsulate `z-index`, this can provoke unexpected behavior with user designs like in #39 and #43.

This is one possible fix, another one could be to set the text layer as `position: absolute` instead of the canvas and keep the default z-index behavior.

Workaround in the meantime : 

```css
 pdf-viewer {
   position: relative;
   z-index: 0;
 }
```