### PR TITLE
Use @Output for after load events

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "pdfjs-dist": "^1.6.329"
   },
   "dependencies": {
+    "@types/pdf": "0.0.31",
     "pdfjs-dist": "^1.6.329"
   },
   "devDependencies": {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -106,7 +106,7 @@
                         [rotation]="rotation"
                         [original-size]="originalSize"
                         [show-all]="showAll"
-                        [after-load-complete]="afterLoadComplete"
+                        (after-load-complete])="afterLoadComplete($event)"
                         [zoom]="zoom"
                         [render-text]="renderText"
             ></pdf-viewer>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -30,10 +30,6 @@ export class AppComponent {
   pdf: any;
   renderText: boolean = true;
 
-  constructor() {
-    this.afterLoadComplete = this.afterLoadComplete.bind(this);
-  }
-
   incrementPage(amount: number) {
     this.page += amount;
   }
@@ -67,7 +63,7 @@ export class AppComponent {
    * Get pdf information after it's loaded
    * @param pdf
    */
-  afterLoadComplete(pdf: any) {
+  afterLoadComplete(pdf: PDFDocumentProxy) {
     this.pdf = pdf;
   }
 }

--- a/src/pdf-viewer/pdf-viewer.component.ts
+++ b/src/pdf-viewer/pdf-viewer.component.ts
@@ -2,7 +2,7 @@
  * Created by vadimdez on 21/06/16.
  */
 import {
-  Component, Input, Output, ElementRef, EventEmitter, OnInit, OnChanges, SimpleChanges
+  Component, Input, Output, ElementRef, EventEmitter, OnInit
 } from '@angular/core';
 import 'pdfjs-dist/build/pdf.combined';
 
@@ -25,7 +25,7 @@ import 'pdfjs-dist/build/pdf.combined';
   `]
 })
 
-export class PdfViewerComponent implements OnInit, OnChanges {
+export class PdfViewerComponent implements OnInit {
   private _showAll: boolean = false;
   private _renderText: boolean = true;
   private _originalSize: boolean = true;

--- a/src/pdf-viewer/pdf-viewer.component.ts
+++ b/src/pdf-viewer/pdf-viewer.component.ts
@@ -2,7 +2,7 @@
  * Created by vadimdez on 21/06/16.
  */
 import {
-  Component, Input, Output, ElementRef, EventEmitter, OnInit
+  Component, Input, Output, ElementRef, EventEmitter, OnInit, OnChanges, SimpleChanges
 } from '@angular/core';
 import 'pdfjs-dist/build/pdf.combined';
 
@@ -25,7 +25,7 @@ import 'pdfjs-dist/build/pdf.combined';
   `]
 })
 
-export class PdfViewerComponent extends OnInit {
+export class PdfViewerComponent implements OnInit, OnChanges {
   private _showAll: boolean = false;
   private _renderText: boolean = true;
   private _originalSize: boolean = true;
@@ -37,11 +37,10 @@ export class PdfViewerComponent extends OnInit {
   private _rotation: number = 0;
   private isInitialised: boolean = false;
   private lastLoaded: string;
-  @Input('after-load-complete') afterLoadComplete: Function;
 
-  constructor(private element: ElementRef) {
-    super();
-  }
+  @Output('after-load-complete') afterLoadComplete = new EventEmitter<PDFDocumentProxy>();
+
+  constructor(private element: ElementRef) { }
 
   ngOnInit() {
     this.main();
@@ -151,9 +150,7 @@ export class PdfViewerComponent extends OnInit {
       this._pdf = pdf;
       this.lastLoaded = src;
 
-      if (this.afterLoadComplete && typeof this.afterLoadComplete === 'function') {
-        this.afterLoadComplete(pdf);
-      }
+      this.afterLoadComplete.emit(pdf);
 
       this.onRender();
     });


### PR DESCRIPTION
This PR creates a breaking change.

Use an `@Output` instead of a callback to handle afterload events.
I didn't changed the name `after-load-complete` but I think `load` should be enough.
