### PR TITLE
force inline style to prevent css override font-family and font-size

### DIFF
--- a/src/pdf-viewer/pdf-viewer.component.ts
+++ b/src/pdf-viewer/pdf-viewer.component.ts
@@ -188,16 +188,20 @@ export class PdfViewerComponent implements OnChanges {
         this.removeAllChildNodes(container);
       }
 
-      return (<any>page).getOperatorList().then(function (opList) {
+      return (<any>page).getOperatorList().then( (opList) => {
         let svgGfx = new (<any>PDFJS).SVGGraphics((<any>page).commonObjs, (<any>page).objs);
 
-        return svgGfx.getSVG(opList, viewport).then(function (svg) {
+        return svgGfx.getSVG(opList, viewport).then( (svg) => {
           let $div = document.createElement('div');
 
           $div.classList.add('page');
           $div.setAttribute('data-page-number', `${ page.pageNumber }`);
 
           $div.appendChild(svg);
+
+          this.convertAttributeToInlineStyle($div, 'font-family');
+          this.convertAttributeToInlineStyle($div, 'font-size');
+
           container.appendChild($div);
         });
       });
@@ -207,6 +211,15 @@ export class PdfViewerComponent implements OnChanges {
   private removeAllChildNodes(element: HTMLElement) {
     while (element.firstChild) {
       element.removeChild(element.firstChild);
+    }
+  }
+
+  private convertAttributeToInlineStyle(parent: HTMLElement, attribute: string) {
+    const matchElements = parent.querySelectorAll(`[${attribute}]`);
+    for (let i = 0, l = matchElements.length; i < l; i++) {
+      const element = matchElements[i];
+      const oldStyle = element.getAttribute('style') || '';
+      element.setAttribute('style', `${oldStyle} ${attribute}: ${element.getAttribute(attribute)};`);
     }
   }
 }


### PR DESCRIPTION
this pull request will resolve #140 

cause:
the priority from css more than attribute. if we use css like 
```css
* { font-family: Tahoma } 
```
it will replace all svg font-family attribute. and it make font render incorrect.

so i will convert all `font-family` and `font-size` attribute to inline style to make sure it will not to override by css.

i think another solution may be render in ```iframe```

