### PR TITLE
Fixed original size for showAll=false

### DIFF
--- a/src/pdf-viewer/pdf-viewer.component.ts
+++ b/src/pdf-viewer/pdf-viewer.component.ts
@@ -518,9 +518,11 @@ export class PdfViewerComponent implements OnChanges, OnInit {
     this._pdf.getPage(pageNumber).then( (page: PDFPageProxy) => {
       let viewport = page.getViewport(this._zoom, this._rotation);
       let container = this.element.nativeElement.querySelector('.pdfViewer');
+      let scale = this._zoom;
 
       if (!this._originalSize) {
         viewport = page.getViewport(this.element.nativeElement.offsetWidth / viewport.width, this._rotation);
+        scale = this.getScale(page.getViewport(1).width);
       }
 
       PdfViewerComponent.removeAllChildNodes(container);
@@ -532,11 +534,11 @@ export class PdfViewerComponent implements OnChanges, OnInit {
       this._pdfLinkService = new (<any>PDFJS).PDFLinkService();
 
       let pdfOptions: PDFViewerParams | any = {
-        container: container,
+        container,
         removePageBorders: true,
         linkService: this._pdfLinkService,
         defaultViewport: viewport,
-        scale: this.getScale(page.getViewport(1).width),
+        scale,
         id: this._page,
         textLayerFactory: new (<any>PDFJS).DefaultTextLayerFactory(),
         annotationLayerFactory: new (<any>PDFJS).DefaultAnnotationLayerFactory()


### PR DESCRIPTION
Hi! Thanks for the ng2-pdf-viewer component.

I've been using your component in my app, and found out that [original-size] attribute doesn't seem to work when you want to show first page only - [show-all]="false".

You can reproduce it on project demo page:
https://vadimdez.github.io/ng2-pdf-viewer/ 
1. Switch on 'Original size' -> PDF is now in original size.
2. Switch off 'Show all pages' -> PDF is now in scaled size (wrong).

The submitted PR should resolve this bug, pls let me know if smth is wrong, or can be improved.

Thx!

