### PR TITLE
Fit original document into the viewport.

### DIFF
--- a/src/pdf-viewer/pdf-viewer.component.ts
+++ b/src/pdf-viewer/pdf-viewer.component.ts
@@ -277,7 +277,7 @@ export class PdfViewerComponent implements OnChanges, OnInit {
   private _rotation: number = 0;
   private _showAll: boolean = true;
   private _canAutoResize: boolean = true;
-  private _fitToPage: boolean = true;
+  private _fitToPage: boolean = false;
   private _externalLinkTarget: string = 'blank';
   private _pdfViewer: any;
   private _pdfLinkService: any;

--- a/src/pdf-viewer/pdf-viewer.component.ts
+++ b/src/pdf-viewer/pdf-viewer.component.ts
@@ -277,6 +277,7 @@ export class PdfViewerComponent implements OnChanges, OnInit {
   private _rotation: number = 0;
   private _showAll: boolean = true;
   private _canAutoResize: boolean = true;
+  private _fitToPage: boolean = true;
   private _externalLinkTarget: string = 'blank';
   private _pdfViewer: any;
   private _pdfLinkService: any;
@@ -392,6 +393,11 @@ export class PdfViewerComponent implements OnChanges, OnInit {
     this._canAutoResize = Boolean(value);
   }
 
+  @Input('fit-to-page')
+  set fitToPage(value: boolean) {
+    this._fitToPage = Boolean(value);
+  }
+
   public setupViewer() {
     (<any>PDFJS).disableTextLayer = !this._renderText;
 
@@ -421,7 +427,7 @@ export class PdfViewerComponent implements OnChanges, OnInit {
       let stickToPage = true;
 
       // Scale the document when it shouldn't be in original size or doesn't fit into the viewport
-      if (!this._originalSize || viewport.width > this.element.nativeElement.offsetWidth) {
+      if (!this._originalSize || (this._fitToPage && viewport.width > this.element.nativeElement.offsetWidth)) {
         scale = this.getScale(page.getViewport(1).width);
         stickToPage = !this._stickToPage;
       }
@@ -537,7 +543,7 @@ export class PdfViewerComponent implements OnChanges, OnInit {
       let scale = this._zoom;
 
       // Scale the document when it shouldn't be in original size or doesn't fit into the viewport
-      if (!this._originalSize || viewport.width > this.element.nativeElement.offsetWidth) {
+      if (!this._originalSize || (this._fitToPage && viewport.width > this.element.nativeElement.offsetWidth)) {
         viewport = page.getViewport(this.element.nativeElement.offsetWidth / viewport.width, this._rotation);
         scale = this.getScale(page.getViewport(1).width);
       }

--- a/src/pdf-viewer/pdf-viewer.component.ts
+++ b/src/pdf-viewer/pdf-viewer.component.ts
@@ -415,13 +415,18 @@ export class PdfViewerComponent implements OnChanges, OnInit {
       return;
     }
 
-    if (this._originalSize) {
-      this._pdfViewer._setScale(this._zoom, true);
-      return;
-    }
-
     this._pdf.getPage(this._pdfViewer.currentPageNumber).then((page: PDFPageProxy) => {
-      this._pdfViewer._setScale(this.getScale(page.getViewport(1).width), !this._stickToPage);
+      const viewport = page.getViewport(this._zoom, this._rotation);
+      let scale = this._zoom;
+      let stickToPage = true;
+
+      // Scale the document when it shouldn't be in original size or doesn't fit into the viewport
+      if (!this._originalSize || viewport.width > this.element.nativeElement.offsetWidth) {
+        scale = this.getScale(page.getViewport(1).width);
+        stickToPage = !this._stickToPage;
+      }
+
+      this._pdfViewer._setScale(scale, stickToPage);
     });
   }
 
@@ -531,7 +536,8 @@ export class PdfViewerComponent implements OnChanges, OnInit {
       let container = this.element.nativeElement.querySelector('.pdfViewer');
       let scale = this._zoom;
 
-      if (!this._originalSize) {
+      // Scale the document when it shouldn't be in original size or doesn't fit into the viewport
+      if (!this._originalSize || viewport.width > this.element.nativeElement.offsetWidth) {
         viewport = page.getViewport(this.element.nativeElement.offsetWidth / viewport.width, this._rotation);
         scale = this.getScale(page.getViewport(1).width);
       }


### PR DESCRIPTION
Hi there,

In my app I need to show the PDF files of different sizes, basically anything that user can upload. Showing the PDF document in original size is very convenient, but currently there is a problem with large documents, which are not fitting into the viewport. This is not very convenient for the user.

This can be avoided by using [original-size]=false, but this means that all smaller documents will be upscaled and look bad.

I thought it would be good to show the document in original size only if it fits into the viewport, otherwise it should be scaled to max-width to fit.

If you have other ideas on approaching this issue, pls let me know.

p.s. Please find attached example of large PDF - [document.pdf](https://github.com/VadimDez/ng2-pdf-viewer/files/1438108/document.pdf)

Thanks!

