### PR TITLE
Don't overwrite PDFJS.workerSrc if already set

### DIFF
--- a/src/pdf-viewer/pdf-viewer.component.ts
+++ b/src/pdf-viewer/pdf-viewer.component.ts
@@ -296,7 +296,7 @@ export class PdfViewerComponent implements OnChanges, OnInit {
   @Output('on-progress') onProgress = new EventEmitter<PDFProgressData>();
 
   constructor(private element: ElementRef) {
-    if (!isSSR()) {
+    if (!isSSR() && typeof PDFJS.workerSrc !== 'string') {
       PDFJS.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${ (PDFJS as any).version }/pdf.worker.min.js`;
     }
   }


### PR DESCRIPTION
If `PDFJS.workerSrc` isn't overwritten when it's set already, then client code is able to set it to the preferred URL.

Related to issue #162 

For instance, my client code can overwrite `PDFJS.workerSrc` as following:

```ts
export class MyComponent implements OnInit {
  ngOnInit() {
    window.PDFJS.workerSrc = '/pdf.worker.min.js';
  }
}
```