### PR TITLE
Public access to number of pages

### DIFF
--- a/src/pdf-viewer/pdf-viewer.component.ts
+++ b/src/pdf-viewer/pdf-viewer.component.ts
@@ -450,6 +450,13 @@ export class PdfViewerComponent implements OnChanges, OnInit {
     });
   }
 
+  public getNumberOfPages(): number {
+    if (this._pdf) {
+      return this._pdf.numPages;
+    }
+    return 0;
+  }
+
   private isValidPageNumber(page: number): boolean {
     return this._pdf.numPages >= page && page >= 1;
   }


### PR DESCRIPTION
For users of the component to properly set up paging then they need to access the number of pages from the private `_pdf` variable.