### PR TITLE
Fix error on resize during loading of pdf

### DIFF
--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -65,7 +65,7 @@ export class PdfViewerComponent implements OnChanges, OnInit {
 
   @HostListener('window:resize', [])
   public onPageResize() {
-    if (!this._canAutoResize) {
+    if (!this._canAutoResize || !this._pdf) {
       return;
     }
 


### PR DESCRIPTION
If browser is resized during the loading of the pdf, an error occurs when trying to access this._pdf before it has been specified.

`ERROR TypeError: Cannot read property 'getPage' of undefined
    at e.updateSize (https://vadimdez.github.io/ng2-pdf-viewer/main.ceb4e328854fe17b171f.bundle.js:1:729905)
    at https://vadimdez.github.io/ng2-pdf-viewer/main.ceb4e328854fe17b171f.bundle.js:1:727735
    at e.invokeTask (https://vadimdez.github.io/ng2-pdf-viewer/polyfills.7bd652c3475ff750ac21.bundle.js:1:22959)
    at Object.onInvokeTask (https://vadimdez.github.io/ng2-pdf-viewer/main.ceb4e328854fe17b171f.bundle.js:1:396262)
    at e.invokeTask (https://vadimdez.github.io/ng2-pdf-viewer/polyfills.7bd652c3475ff750ac21.bundle.js:1:22880)
    at t.runTask (https://vadimdez.github.io/ng2-pdf-viewer/polyfills.7bd652c3475ff750ac21.bundle.js:1:18137)
    at t.invokeTask (https://vadimdez.github.io/ng2-pdf-viewer/polyfills.7bd652c3475ff750ac21.bundle.js:1:24049)
    at invoke (https://vadimdez.github.io/ng2-pdf-viewer/polyfills.7bd652c3475ff750ac21.bundle.js:1:23940)
    at n.args.(anonymous function) (https://vadimdez.github.io/ng2-pdf-viewer/polyfills.7bd652c3475ff750ac21.bundle.js:1:38992)`

The issue can be reproduced by resizing the https://vadimdez.github.io/ng2-pdf-viewer/ window when pdf is loading.