### PR TITLE
enable setting render text mode to enchanced

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ export class AppComponent {
 * [[stick-to-page]](#stick-to-page)
 * [[external-link-target]](#external-link-target)
 * [[render-text]](#render-text)
+* [[render-text-mode]](#render-text-mode)
 * [[rotation]](#rotation)
 * [[zoom]](#zoom)
 * [[original-size]](#original-size)
@@ -182,6 +183,19 @@ Sticks view to the page. Works in combination with `[show-all]="true"` and `page
 Enable text rendering, allows to select text
 ```
 [render-text]="true"
+```
+
+#### [render-text-mode]
+
+| Property | Type | Required |
+| --- | ---- | --- |
+| [render-text-mode] | *RenderTextMode* | *Optional* |
+
+Used in combination with `[render-text]="true"`
+
+Set text rendering mode to RenderTextMode.DISABLED, RenderTextMode.ENABLED or RenderTextMode.ENHANCED
+```
+[render-text-mode]="1"
 ```
 
 #### [external-link-target]

--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -19,6 +19,12 @@ if (!isSSR()) {
   PDFJS.verbosity = PDFJS.VerbosityLevel.ERRORS;
 }
 
+export enum RenderTextMode {
+  DISABLED,
+  ENABLED,
+  ENHANCED
+}
+
 @Component({
   selector: 'pdf-viewer',
   template: `<div class="ng2-pdf-viewer-container"><div class="pdfViewer"></div></div>`,
@@ -34,6 +40,7 @@ export class PdfViewerComponent implements OnChanges, OnInit, OnDestroy {
 
   private _cMapsUrl: string = `https://unpkg.com/pdfjs-dist@${ (PDFJS as any).version }/cmaps/`;
   private _renderText: boolean = true;
+  private _renderTextMode: RenderTextMode = RenderTextMode.ENABLED;
   private _stickToPage: boolean = false;
   private _originalSize: boolean = true;
   private _pdf: PDFDocumentProxy;
@@ -176,6 +183,11 @@ export class PdfViewerComponent implements OnChanges, OnInit, OnDestroy {
     this._renderText = renderText;
   }
 
+  @Input('render-text-mode')
+  set renderTextMode(renderTextMode: RenderTextMode) {
+    this._renderTextMode = renderTextMode;
+  }
+
   @Input('original-size')
   set originalSize(originalSize: boolean) {
     this._originalSize = originalSize;
@@ -240,7 +252,7 @@ export class PdfViewerComponent implements OnChanges, OnInit, OnDestroy {
       container: this.element.nativeElement.querySelector('div'),
       removePageBorders: true,
       linkService: this.pdfLinkService,
-      textLayerMode: this._renderText ? 1 : 0
+      textLayerMode: this._renderText ? this._renderTextMode : RenderTextMode.DISABLED
     };
 
     this.pdfViewer = new PDFJSViewer.PDFViewer(pdfOptions);


### PR DESCRIPTION
There is a problem with selecting text in browsers other that Firefox, selection jump to the top/bottom of
the page when cursor moves over white space ( space, paragraph, new line etc. ). I am pretty sure the
problem is with additional div.endOfPage element, only Firefox disables user-select on it.

When you set textLayerMode to 'ENHANCED' then it works as expected.