### PR TITLE
update page number upon page changing event

### DIFF
--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -394,6 +394,12 @@ export class PdfViewerComponent
 
     const eventBus = createEventBus(PDFJSViewer);
 
+    eventBus.on('pagechanging', e => {
+      if (e.pageNumber != this._page) {
+        this.page = e.pageNumber;
+      }
+    });
+
     eventBus.on('pagerendered', e => {
       this.pageRendered.emit(e);
     });

--- a/src/app/utils/event-bus-utils.ts
+++ b/src/app/utils/event-bus-utils.ts
@@ -26,9 +26,9 @@ function attachDOMEventsToEventBus(eventBus: any) {
     });
     evt.source.textLayerDiv.dispatchEvent(event);
   });
-  eventBus.on('pagechange', function(evt) {
+  eventBus.on('pagechanging', function(evt) {
     const event = document.createEvent('UIEvents');
-    event.initUIEvent('pagechange', true, true, window, 0);
+    event.initUIEvent('pagechanging', true, true, window, 0);
     event['pageNumber'] = evt.pageNumber;
     evt.source.container.dispatchEvent(event);
   });


### PR DESCRIPTION
After clicking an internal navigation link the current page number will now be correct for single page view mode. 
Issue #474 