### PR TITLE
Add support to get pdf page coordinate when page clicked

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ export class AppComponent {
 * [[show-borders]](#show-borders)
 * [(after-load-complete)](#after-load-complete)
 * [(page-rendered)](#page-rendered)
+* [(on-page-click)](#on-page-click)
 * [(text-layer-rendered)](#text-layer-rendered)
 * [(error)](#error)
 * [(on-progress)](#on-progress)
@@ -384,6 +385,31 @@ And then bind it to `<pdf-viewer>`:
 
 ```angular2html
 (text-layer-rendered)="textLayerRendered($event)"
+```
+
+#### (on-page-click)
+
+| Property | Type | Required |
+| --- | ---- | --- |
+| (on-page-click) | *callback* | *Optional* |
+
+Get the pdf coordinate when page clicked.
+
+pdf.js uses a transformation matrix for each page to allow it to convert between PDF and viewer coordinates.
+with this callback, we can get the coordinate in pdf when the page viewer clicked. 
+
+Define callback in your component's class
+
+```typescript
+onPageClick(coordinate: PDFPageCoordinate) {
+  // 'coordinate' provides the real coordinate in pdf page.
+}
+```
+
+Then add it to `pdf-component` in component's template
+
+```html
+(on-page-click)="onPageClick($event)"
 ```
 
 #### (error)

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -178,6 +178,6 @@
       [fit-to-page]="fitToPage" (after-load-complete)="afterLoadComplete($event)" [zoom]="zoom" [show-all]="showAll"
       [stick-to-page]="stickToPage" [render-text]="renderText" [external-link-target]="'blank'"
       [autoresize]="autoresize" (error)="onError($event)" (on-progress)="onProgress($event)"
-      (page-rendered)="pageRendered($event)"></pdf-viewer>
+      (page-rendered)="pageRendered($event)" (on-page-click)="onPageClick($event)"></pdf-viewer>
   </mat-drawer-content>
 </mat-drawer-container>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,7 +8,7 @@ import {
   PDFSource
 } from './pdf-viewer/pdf-viewer.module';
 
-import { PdfViewerComponent } from './pdf-viewer/pdf-viewer.component';
+import { PDFPageCoordinate, PdfViewerComponent } from './pdf-viewer/pdf-viewer.component';
 
 @Component({
   moduleId: module.id,
@@ -196,6 +196,14 @@ export class AppComponent {
    */
   pageRendered(e: CustomEvent) {
     console.log('(page-rendered)', e);
+  }
+
+  /**
+   * Get the coordinate when mouse/hand clicked/touched the page.
+   * @param coordinate
+   */
+  onPageClick(coordinate: PDFPageCoordinate) {
+    console.log('(page-clicked)', coordinate);
   }
 
   searchQueryChanged(newQuery: string) {


### PR DESCRIPTION
pdf.js uses a transformation matrix for each page to allow it to convert between PDF and viewer coordinates. with this feature, we can get the coordinate in pdf when the page viewer clicked.