### PR TITLE
fix: explicitly set box-sizing of a page to initial

### DIFF
--- a/src/app/pdf-viewer/pdf-viewer.component.scss
+++ b/src/app/pdf-viewer/pdf-viewer.component.scss
@@ -50,7 +50,7 @@
     ::-moz-selection {
       background: rgb(0, 0, 255);
     }
-    
+
     ::selection {
       background: rgb(0, 0, 255);
     }
@@ -357,6 +357,7 @@
       // "transparent" makes the border not show up in Safari. But adding a light transparent color did
       // rgba(0,0,0,0.01). But there needs to be an alpha value larger than 0.
       border: 9px solid rgba(0,0,0,0.01);
+      box-sizing: initial;
       background-clip: content-box;
       -o-border-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAQAAADYWf5HAAAA6UlEQVR4Xl2Pi2rEMAwE16fm1f7/r14v7w4rI0IzLAF7hLxNevBSEMEF5+OilNCsRd8ZMyn+a4NmsOT8WJw1lFbSYgGFzF2bLFoLjTClWjKKGRWpDYAGXUnZ4uhbBUzF3Oe/GG/ue2fn4GgsyXhNgysV2JnrhKEMg4fEZcALmiKbNhBBRFpSyDOj1G4QOVly6O1FV54ZZq8OVygrciDt6JazRgi1ljTPH0gbrPmHPXAbCiDd4GawIjip1TPh9tt2sz24qaCjr/jAb/GBFTbq9KZ7Ke/Cqt8nayUikZKsWZK7Fe6bg5dOUt8fZHWG2BHc+6EAAAAASUVORK5CYII=') 9 9 repeat;
       border-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAQAAADYWf5HAAAA6UlEQVR4Xl2Pi2rEMAwE16fm1f7/r14v7w4rI0IzLAF7hLxNevBSEMEF5+OilNCsRd8ZMyn+a4NmsOT8WJw1lFbSYgGFzF2bLFoLjTClWjKKGRWpDYAGXUnZ4uhbBUzF3Oe/GG/ue2fn4GgsyXhNgysV2JnrhKEMg4fEZcALmiKbNhBBRFpSyDOj1G4QOVly6O1FV54ZZq8OVygrciDt6JazRgi1ljTPH0gbrPmHPXAbCiDd4GawIjip1TPh9tt2sz24qaCjr/jAb/GBFTbq9KZ7Ke/Cqt8nayUikZKsWZK7Fe6bg5dOUt8fZHWG2BHc+6EAAAAASUVORK5CYII=') 9 9 repeat;
@@ -367,7 +368,7 @@
       margin: 0px auto 10px auto;
       border: none;
     }
-    
+
     padding-bottom: 10px;
     &.removePageBorders {
       padding-bottom: 0;


### PR DESCRIPTION
If we do not do that it would be overwritten by eg Ionic and the border does not look like as expected.