### PR TITLE
Fix in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Defines how the Zoom scale is computed when  `[original-size]="false"`, by defau
 - *'page-fit'* with zoom of 1 will display a page that will be scaled to either width or height to fit completely in the container
 
 ```
-[zoom-scale]="page-width"
+[zoom-scale]="'page-width'"
 ```
 
 #### [original-size]


### PR DESCRIPTION
I see two possibilities in the usage:

1. `[zoom-scale]="'page-width'"`
2. `zoom-scale="page-width"`