### PR TITLE
⬆️ Upgrade pdfjs from 2.7.570 to 2.9.359

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
   },
   "homepage": "https://github.com/VadimDez/ng2-pdf-viewer#readme",
   "dependencies": {
-    "pdfjs-dist": "~2.7.570",
+    "pdfjs-dist": "~2.9.359",
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "pdfjs-dist": "~2.7.570"
+    "pdfjs-dist": "~2.9.359"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1101.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/VadimDez/ng2-pdf-viewer#readme",
   "dependencies": {
     "pdfjs-dist": "~2.7.570",
-    "tslib": "^2.0.0"
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "pdfjs-dist": "~2.7.570"

--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -17,8 +17,8 @@ import {
 } from '@angular/core';
 import { from, fromEvent, Subject } from 'rxjs';
 import { debounceTime, filter, takeUntil } from 'rxjs/operators';
-import * as PDFJS from 'pdfjs-dist/es5/build/pdf';
-import * as PDFJSViewer from 'pdfjs-dist/es5/web/pdf_viewer';
+import * as PDFJS from 'pdfjs-dist/legacy/build/pdf';
+import * as PDFJSViewer from 'pdfjs-dist/legacy/web/pdf_viewer';
 
 import { createEventBus } from '../utils/event-bus-utils';
 import { assign, isSSR } from '../utils/helpers';
@@ -231,7 +231,7 @@ export class PdfViewerComponent
       pdfWorkerSrc = (window as any).pdfWorkerSrc;
     } else {
       pdfWorkerSrc = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${(PDFJS as any).version
-        }/es5/build/pdf.worker.js`;
+        }/legacy/build/pdf.worker.js`;
     }
 
     assign(PDFJS.GlobalWorkerOptions, "workerSrc", pdfWorkerSrc);


### PR DESCRIPTION
The new version of PDFJs fixed several bugs and improved the selectable text rendering layer.