### PR TITLE
Fix issue #813 pageChange emit

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -58,6 +58,7 @@ export class AppComponent implements OnInit {
       if (xhr.status === 200) {
         const blob = new Blob([xhr.response], { type: 'application/pdf' });
         this.pdfSrc = URL.createObjectURL(blob);
+        this.page = 1;
       }
     };
 
@@ -94,6 +95,7 @@ export class AppComponent implements OnInit {
 
       reader.onload = (e: any) => {
         this.pdfSrc = e.target.result;
+        this.page = 1;
       };
 
       reader.readAsArrayBuffer($pdf.files[0]);

--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -108,18 +108,19 @@ export class PdfViewerComponent
   }
 
   @Input('page')
-  set page(_page) {
-    _page = parseInt(_page, 10) || 1;
-    const originalPage = _page;
+  set page(page) {
+    page = parseInt(page, 10);
 
     if (this._pdf) {
-      _page = this.getValidPageNumber(_page);
+      const validPage = this.getValidPageNumber(page);
+      if (page !== validPage)
+      {
+        page = validPage;
+        this.pageChange.emit(validPage);
+      }
     }
 
-    this._page = _page;
-    if (originalPage !== _page) {
-      this.pageChange.emit(_page);
-    }
+    this._page = page;
   }
 
   @Input('render-text')
@@ -452,7 +453,11 @@ export class PdfViewerComponent
       .pipe(takeUntil(this.destroy$))
       .subscribe(({ pageNumber }) => {
         if (pageNumber !== this._page) {
-          this.page = pageNumber;
+          if (this._pdf) {
+            pageNumber = this.getValidPageNumber(pageNumber);
+          }
+          this._page = pageNumber;
+          this.pageChange.emit(pageNumber);
         }
       });
 
@@ -501,7 +506,7 @@ export class PdfViewerComponent
   }
 
   private getValidPageNumber(page: number): number {
-    if (page < 1) {
+    if (Number.isNaN(page) || page < 1) {
       return 1;
     }
 


### PR DESCRIPTION
Fix for #813 
Breaking the loop of [(page)] two-way binding, while still emitting pageChange and making sure to return the valid page number incase it had to be adjusted due to an invalid page number being entered.
Due to this, links within a PDF work again as well.

