### PR TITLE
feat: upgrade to pdfjs-dist 2.11.338

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9653,9 +9653,9 @@
       }
     },
     "pdfjs-dist": {
-      "version": "2.7.570",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.7.570.tgz",
-      "integrity": "sha512-/ZkA1FwkEOyDaq11JhMLazdwQAA0F9uwrP7h/1L9Akt9KWh1G5/tkzS+bPuUELq2s2GDFnaT+kooN/aSjT7DXQ=="
+      "version": "2.11.338",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.11.338.tgz",
+      "integrity": "sha512-Ti5VTB0VvSdtTtc7TG71ghMx0SEuNcEs4ghVuZxW0p6OqLjMc0xekZV1B+MmlxEG2Du2e5jgazucWIG/SXTcdA=="
     },
     "pend": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
   },
   "homepage": "https://github.com/VadimDez/ng2-pdf-viewer#readme",
   "dependencies": {
-    "pdfjs-dist": "~2.7.570",
+    "pdfjs-dist": "~2.11.338",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "pdfjs-dist": "~2.7.570"
+    "pdfjs-dist": "~2.11.338"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1101.2",

--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -17,8 +17,8 @@ import {
 } from '@angular/core';
 import { from, fromEvent, Subject } from 'rxjs';
 import { debounceTime, filter, takeUntil } from 'rxjs/operators';
-import * as PDFJS from 'pdfjs-dist/es5/build/pdf';
-import * as PDFJSViewer from 'pdfjs-dist/es5/web/pdf_viewer';
+import * as PDFJS from 'pdfjs-dist/legacy/build/pdf';
+import * as PDFJSViewer from 'pdfjs-dist/legacy/web/pdf_viewer';
 
 import { createEventBus } from '../utils/event-bus-utils';
 import { assign, isSSR } from '../utils/helpers';
@@ -29,10 +29,11 @@ import type {
   PDFProgressData,
   PDFDocumentProxy,
   PDFDocumentLoadingTask,
+  PDFViewerOptions
 } from './typings';
 
 if (!isSSR()) {
-  assign(PDFJS, "verbosity", PDFJS.VerbosityLevel.ERRORS);
+  assign(PDFJS, 'verbosity', PDFJS.VerbosityLevel.INFOS);
 }
 
 export enum RenderTextMode {
@@ -231,10 +232,10 @@ export class PdfViewerComponent
       pdfWorkerSrc = (window as any).pdfWorkerSrc;
     } else {
       pdfWorkerSrc = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${(PDFJS as any).version
-        }/es5/build/pdf.worker.js`;
+        }/legacy/build/pdf.worker.js`;
     }
 
-    assign(PDFJS.GlobalWorkerOptions, "workerSrc", pdfWorkerSrc);
+    assign(PDFJS.GlobalWorkerOptions, 'workerSrc', pdfWorkerSrc);
   }
 
   ngAfterViewChecked(): void {
@@ -384,7 +385,7 @@ export class PdfViewerComponent
   }
 
   private setupMultiPageViewer() {
-    assign(PDFJS, "disableTextLayer", !this._renderText);
+    assign(PDFJS, 'disableTextLayer', !this._renderText);
 
     const eventBus = createEventBus(PDFJSViewer, this.destroy$);
 
@@ -427,7 +428,7 @@ export class PdfViewerComponent
       eventBus
     });
 
-    const pdfOptions = {
+    const pdfOptions: PDFViewerOptions = {
       eventBus,
       container: this.element.nativeElement.querySelector('div'),
       removePageBorders: !this._showBorders,
@@ -435,7 +436,9 @@ export class PdfViewerComponent
       textLayerMode: this._renderText
         ? this._renderTextMode
         : RenderTextMode.DISABLED,
-      findController: this.pdfMultiPageFindController
+      findController: this.pdfMultiPageFindController,
+      renderer: 'canvas',
+      l10n: undefined
     };
 
     this.pdfMultiPageViewer = new PDFJSViewer.PDFViewer(pdfOptions);
@@ -444,7 +447,7 @@ export class PdfViewerComponent
   }
 
   private setupSinglePageViewer() {
-    assign(PDFJS, "disableTextLayer", !this._renderText);
+    assign(PDFJS, 'disableTextLayer', !this._renderText);
 
     const eventBus = createEventBus(PDFJSViewer, this.destroy$);
 

--- a/src/app/pdf-viewer/typings.ts
+++ b/src/app/pdf-viewer/typings.ts
@@ -1,7 +1,8 @@
-export type PDFPageProxy = import('pdfjs-dist/types/display/api').PDFPageProxy;
-export type PDFSource = import('pdfjs-dist/types/display/api').DocumentInitParameters;
-export type PDFDocumentProxy = import('pdfjs-dist/types/display/api').PDFDocumentProxy;
-export type PDFDocumentLoadingTask = import('pdfjs-dist/types/display/api').PDFDocumentLoadingTask;
+export type PDFPageProxy = import('pdfjs-dist/types/src/display/api').PDFPageProxy;
+export type PDFSource = import('pdfjs-dist/types/src/display/api').DocumentInitParameters;
+export type PDFDocumentProxy = import('pdfjs-dist/types/src/display/api').PDFDocumentProxy;
+export type PDFDocumentLoadingTask = import('pdfjs-dist/types/src/display/api').PDFDocumentLoadingTask;
+export type PDFViewerOptions = import('pdfjs-dist/types/web/base_viewer').PDFViewerOptions;
 
 export interface PDFProgressData {
   loaded: number;


### PR DESCRIPTION
This PR updates pdfjs-dist to the latest version (2.11.338), changing the library's code accordingly:

- Change imports to match PDF.js's new folder structure (es5 build artifacts are now in the 'legacy' folder);
- Import and use the type PDFViewerOptions for pdfOptions (properties 'renderer' and 'l10n' must be set now);
- Use ' instead of " for assign calls.