### PR TITLE
Give sane default to host

### DIFF
--- a/src/app/pdf-viewer/pdf-viewer.component.scss
+++ b/src/app/pdf-viewer/pdf-viewer.component.scss
@@ -6,6 +6,11 @@
   -webkit-overflow-scrolling: touch;
 }
 
+:host {
+  display: block;
+  position: relative;
+}
+
 :host ::ng-deep {
   /* Copyright 2014 Mozilla Foundation
  *


### PR DESCRIPTION
Giving the host `display: block` makes him immediately visible. `position: relative` is there to prevent https://github.com/VadimDez/ng2-pdf-viewer/issues/811.