### PR TITLE
fix can't load document after error

### DIFF
--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -579,6 +579,7 @@ export class PdfViewerComponent
           this.update();
         },
         error: (error) => {
+          this.lastLoaded = null;
           this.onError.emit(error);
         }
       });


### PR DESCRIPTION
Resets the lastLoaded value when loading a document fails