### PR TITLE
fix: correct broken outline navigation

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -176,7 +176,7 @@ export class AppComponent implements OnInit {
    * @param destination pdf navigate to
    */
   navigateTo(destination: any) {
-    this.pdfComponent.pdfLinkService.navigateTo(destination);
+    this.pdfComponent.pdfLinkService.goToDestination(destination);
   }
 
   /**


### PR DESCRIPTION
As PDFJS refactored the PDFLinkService to use goToDestination, reflect this in example app.