### PR TITLE
fix #947 : reset this._latestScrolledPage on clear method

### DIFF
--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -346,6 +346,7 @@ export class PdfViewerComponent
     }
 
     if (this._pdf) {
+      this._latestScrolledPage = 0;
       this._pdf.destroy();
       this._pdf = null;
       this.pdfViewer.setDocument(null);


### PR DESCRIPTION
Solution explained on the issue :

Add this._latestScrolledPage = 0; on clear method to reset this value on pdfLoad and correct the current bug.