### PR TITLE
feat: Support version specific pdf.worker.js url

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,8 +515,17 @@ In your code update `path` to the worker to be for example `/pdf.worker.js`
 ```typescript
 (window as any).pdfWorkerSrc = '/pdf.worker.js';
 ```
+
 *This should be set before `pdf-viewer` component is rendered.*
 
+If you ever have a (super rare) edge case where you run in an environment that multiple
+components are somehow loaded within the same web page, sharing the same window,
+but using different versions of pdf.worker, support has been added.  You can do the
+above, except that you can append the specific version of pdfjs required and override the
+custom path *just for that version*.  This way setting the global window var won't conflict.
+```typescript
+(window as any)["pdfWorkerSrc2.14.305"] = '/pdf.worker.js';
+```
 
 ## Search in the PDF
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --configuration production=true",
+    "build": "ng build --configuration production",
     "build:stats": "ng build --stats-json",
     "analyze": "webpack-bundle-analyzer dist/stats.json",
     "test": "ng test --watch false",

--- a/src/app/pdf-viewer/pdf-viewer.component.spec.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.spec.ts
@@ -4,6 +4,9 @@ import { Component } from '@angular/core';
 import { PdfViewerComponent } from './pdf-viewer.component';
 import { PdfViewerModule } from './pdf-viewer.module';
 
+import { GlobalWorkerOptions } from 'pdfjs-dist';
+import * as PDFJS from 'pdfjs-dist/build/pdf';
+
 @Component({
   template: `
     <pdf-viewer></pdf-viewer>
@@ -140,4 +143,51 @@ describe('AppComponent', () => {
       });
     });
   });
+
+  describe('pdf.worker location', () => {
+    const curPdfJsVersion = (PDFJS as any).version;
+
+    beforeEach(() => {
+      (window as any).pdfWorkerSrc = undefined;
+      (window as any)["pdfWorkerSrc1.2.3"] = undefined;
+      (window as any)[`pdfWorkerSrc${curPdfJsVersion}`] = undefined;
+
+    });
+
+    it('should default to the cdn', () => {
+      pdfViewerFixture = TestBed.createComponent(PdfViewerComponent);
+      pdfViewer = pdfViewerFixture.debugElement.componentInstance;
+
+      expect(GlobalWorkerOptions.workerSrc).toBe(`https://cdn.jsdelivr.net/npm/pdfjs-dist@${curPdfJsVersion
+        }/legacy/build/pdf.worker.min.js`);
+    })
+
+    it('should support global override', () => {
+      (window as any).pdfWorkerSrc = 'globaloverride';
+
+      pdfViewerFixture = TestBed.createComponent(PdfViewerComponent);
+      pdfViewer = pdfViewerFixture.debugElement.componentInstance;
+
+      expect(GlobalWorkerOptions.workerSrc).toBe('globaloverride');
+    })
+
+    it('should default to the cdn when version override does not match version', () => {
+      (window as any)["pdfWorkerSrc1.2.3"] = 'globaloverride';
+
+      pdfViewerFixture = TestBed.createComponent(PdfViewerComponent);
+      pdfViewer = pdfViewerFixture.debugElement.componentInstance;
+
+      expect(GlobalWorkerOptions.workerSrc).toBe(`https://cdn.jsdelivr.net/npm/pdfjs-dist@${curPdfJsVersion
+        }/legacy/build/pdf.worker.min.js`);
+    })
+
+    it('should take version override with version match', () => {
+      (window as any)[`pdfWorkerSrc${curPdfJsVersion}`] = 'globaloverride';
+
+      pdfViewerFixture = TestBed.createComponent(PdfViewerComponent);
+      pdfViewer = pdfViewerFixture.debugElement.componentInstance;
+
+      expect(GlobalWorkerOptions.workerSrc).toBe(`globaloverride`);
+    })
+  })
 });

--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -227,14 +227,19 @@ export class PdfViewerComponent
 
     let pdfWorkerSrc: string;
 
-    if (
+    const pdfJsVersion = (PDFJS as any).version;
+    const versionSpecificPdfWorkerUrl = window[`pdfWorkerSrc${pdfJsVersion}`];
+
+    if (versionSpecificPdfWorkerUrl) {
+      pdfWorkerSrc = versionSpecificPdfWorkerUrl;
+    } else if (
       window.hasOwnProperty('pdfWorkerSrc') &&
       typeof (window as any).pdfWorkerSrc === 'string' &&
       (window as any).pdfWorkerSrc
     ) {
       pdfWorkerSrc = (window as any).pdfWorkerSrc;
     } else {
-      pdfWorkerSrc = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${(PDFJS as any).version
+      pdfWorkerSrc = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfJsVersion
         }/legacy/build/pdf.worker.min.js`;
     }
 


### PR DESCRIPTION
some environments can have multiple versions of the pdf viewer in the same browser instance, so url overrides need to have the ability to be specific to a version