### PR TITLE
fix: Ensure initialization before setupViewer

### DIFF
--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -497,6 +497,10 @@ export class PdfViewerComponent
 
     this.clear();
 
+    if (!this.isInitialized) {
+      this.initialize();
+    }
+    
     this.setupViewer();
 
     this.loadingTask = PDFJS.getDocument(this.getDocumentParams());


### PR DESCRIPTION
in rare cases, the `ngAfterViewChecked -> setTimeout -> initialize` path may not complete (because of `setTimeout`) before the next `ngOnChanges -> loadPDF` occurs.  this is an issue because `setupViewer -> initPDFServices` expects `this.eventBus` to have been created, which normally happens in `initialize -> initEventBus`.