### PR TITLE
Fix enabled Stick To Page throws Error if new pdf is loaded

### DIFF
--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -547,7 +547,7 @@ export class PdfViewerComponent
     if (this._stickToPage) {
       setTimeout(() => {
         this.pdfViewer.currentPageNumber = this._page;
-      });
+      }, 100);
     }
 
     this.updateSize();


### PR DESCRIPTION
Fix #946.