### PR TITLE
feat(loadPdf): emit error when source is missing

### DIFF
--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -488,6 +488,7 @@ export class PdfViewerComponent
 
   private loadPDF() {
     if (!this.src) {
+      this.onError.emit();
       return;
     }
 


### PR DESCRIPTION
Src undefined didn't emit error, which block acting on failed loading multiple time.