### PR TITLE
Update pdf-viewer.component.scss

### DIFF
--- a/src/app/pdf-viewer/pdf-viewer.component.scss
+++ b/src/app/pdf-viewer/pdf-viewer.component.scss
@@ -907,7 +907,7 @@
   }
 
   .pdfViewer.removePageBorders .page {
-    margin: 0 auto 10px;
+    margin: var(--removePageBorders-margin, 0 auto 10px);
     border: none;
   }
 


### PR DESCRIPTION
Add `--removePageBorders-maring` css variable to `.removePageBorders .page` to let people remove the bottom `10px` margin which is forcer a single page to overflow