### PR TITLE
Chore: update pdfjs to 3.11.174, resolve CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "10.1.0",
       "license": "MIT",
       "dependencies": {
-        "pdfjs-dist": "^3.10.111",
+        "pdfjs-dist": "^3.11.174",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -11206,9 +11206,9 @@
       }
     },
     "node_modules/pdfjs-dist": {
-      "version": "3.10.111",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.10.111.tgz",
-      "integrity": "sha512-+SXXGN/3YTNQSK5Ae7EyqQuR+4IAsNunJq/Us5ByOkRJ45qBXXOwkiWi3RIDU+CyF+ak5eSWXl2FQW2PKBrsRA==",
+      "version": "3.11.174",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
+      "integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
       "engines": {
         "node": ">=18"
       },
@@ -23690,9 +23690,9 @@
       "optional": true
     },
     "pdfjs-dist": {
-      "version": "3.10.111",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.10.111.tgz",
-      "integrity": "sha512-+SXXGN/3YTNQSK5Ae7EyqQuR+4IAsNunJq/Us5ByOkRJ45qBXXOwkiWi3RIDU+CyF+ak5eSWXl2FQW2PKBrsRA==",
+      "version": "3.11.174",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
+      "integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
       "requires": {
         "canvas": "^2.11.2",
         "path2d-polyfill": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/VadimDez/ng2-pdf-viewer#readme",
   "dependencies": {
-    "pdfjs-dist": "^3.10.111",
+    "pdfjs-dist": "^3.11.174",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/src/app/pdf-viewer/pdf-viewer.component.spec.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.spec.ts
@@ -114,7 +114,8 @@ describe('AppComponent', () => {
         url: src,
         cMapUrl,
         cMapPacked: true,
-        enableXfa: true
+        enableXfa: true,
+        isEvalSupported: false,
       });
     });
 
@@ -126,7 +127,8 @@ describe('AppComponent', () => {
         url: src,
         cMapUrl,
         cMapPacked: true,
-        enableXfa: true
+        enableXfa: true,
+        isEvalSupported: false,
       });
     });
 
@@ -139,7 +141,8 @@ describe('AppComponent', () => {
         url: srcUrl,
         cMapUrl,
         cMapPacked: true,
-        enableXfa: true
+        enableXfa: true,
+        isEvalSupported: false,
       });
     });
   });

--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -466,8 +466,9 @@ export class PdfViewerComponent
     const params: any = {
       cMapUrl: this._cMapsUrl,
       cMapPacked: true,
-      enableXfa: true
+      enableXfa: true,
     };
+    params.isEvalSupported = false; // http://cve.org/CVERecord?id=CVE-2024-4367
 
     if (srcType === 'string') {
       params.url = this.src;


### PR DESCRIPTION
Hey glad to see the project is still going! Thanks for merging my other update PR 🙏

Not to be annoying but I figured we might as well go to the latest 3.x, I also included a change to disable JS execution which is an acceptable solution to https://www.cve.org/CVERecord?id=CVE-2024-4367 AFAIK

Closes #1088
Supersedes #1089