### PR TITLE
Explicitely switch AnnotationEditor off

### DIFF
--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -426,6 +426,7 @@ export class PdfViewerComponent
       findController: this.pdfFindController,
       l10n: new PDFJSViewer.GenericL10n('en'),
       imageResourcesPath: this._imageResourcesPath,
+      annotationEditorMode: PDFJS.AnnotationEditorType.DISABLE,      
     };
   }
 


### PR DESCRIPTION
avoid errors that prevents switching pdf documents, as the  AnnotationEditorUIManager.destroy errors about uninitialized properties.