### PR TITLE
Fix #999: Ensure that the rotation in the viewer is not set too early

### DIFF
--- a/src/app/pdf-viewer/pdf-viewer.component.scss
+++ b/src/app/pdf-viewer/pdf-viewer.component.scss
@@ -72,6 +72,7 @@
     -moz-text-size-adjust: none;
     text-size-adjust: none;
     forced-color-adjust: none;
+    transform-origin: 0 0;
   }
 
   .textLayer span,

--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -541,9 +541,10 @@ export class PdfViewerComponent
       this._rotation !== 0 ||
       this.pdfViewer.pagesRotation !== this._rotation
     ) {
-      setTimeout(() => {
-        this.pdfViewer.pagesRotation = this._rotation;
-      });
+      // wait until at least the first page is available.
+      this.pdfViewer.firstPagePromise?.then(
+        () => (this.pdfViewer.pagesRotation = this._rotation)
+      );
     }
 
     if (this._stickToPage) {


### PR DESCRIPTION
- Fix for #999 

- Also fixes that rotated documents where overflowing and thus showing an unnecessary scrollbar. Taken from https://github.com/mozilla/pdf.js/blob/master/web/text_layer_builder.css#L25