### PR TITLE
Fix: use page init for first updateSize

### DIFF
--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -351,12 +351,9 @@ export class PdfViewerComponent
             stickToPage = !this._stickToPage;
           }
 
-          // delay to ensure that pages are ready
-          this.pdfViewer.pagesPromise?.then(() => {
-            this.pdfViewer.currentScale = scale;
-            if (stickToPage)
-              this.pdfViewer.scrollPageIntoView({ pageNumber: page.pageNumber, ignoreDestinationZoom: true })
-          });
+          this.pdfViewer.currentScale = scale;
+          if (stickToPage)
+            this.pdfViewer.scrollPageIntoView({ pageNumber: page.pageNumber, ignoreDestinationZoom: true })
         }
       });
   }
@@ -573,7 +570,14 @@ export class PdfViewerComponent
       });
     }
 
-    this.updateSize();
+    if (!this.pdfViewer._pages?.length) {
+      // the first time we wait until pages init
+      this.pageInitialized.subscribe(() => {
+        this.updateSize();
+      })
+    } else {
+      this.updateSize();
+    }
   }
 
   private getScale(viewportWidth: number, viewportHeight: number) {

--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -572,8 +572,9 @@ export class PdfViewerComponent
 
     if (!this.pdfViewer._pages?.length) {
       // the first time we wait until pages init
-      this.pageInitialized.subscribe(() => {
+      const sub = this.pageInitialized.subscribe(() => {
         this.updateSize();
+        sub.unsubscribe();
       })
     } else {
       this.updateSize();


### PR DESCRIPTION
Caused by https://github.com/VadimDez/ng2-pdf-viewer/pull/1098

Closes #1145

Let me know if I've missed anything here, of course.

<img width="1767" alt="Screenshot 2024-10-29 at 12 02 45 PM" src="https://github.com/user-attachments/assets/994b500b-6c08-4460-bfab-597fd00bb125">

Seems to fix the flash-of-unzoomed-pdf (FOUP):


https://github.com/user-attachments/assets/259b4343-23ce-480d-95f9-799c1431d739


