### PR TITLE
Added pdfjs 5.4.0 + wasm support (default and custom)

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,10 @@ In your code update `path` to the worker to be for example `/pdf.worker.mjs`
 ```typescript
 (window as any).pdfWorkerSrc = '/pdf.worker.mjs';
 ```
+If you are rendering JPEG2000 images, update `path` to the wasmUrl to be for example `/wasm/`
+```typescript
+(window as any).wasmUrl = '/wasm/';
+```
 
 *This should be set before `pdf-viewer` component is rendered.*
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/VadimDez/ng2-pdf-viewer#readme",
   "dependencies": {
-    "pdfjs-dist": "4.8.69",
+    "pdfjs-dist": "^5.4.0",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -41,6 +41,14 @@ export class AppComponent implements OnInit {
   @ViewChild(PdfViewerComponent)
   private pdfComponent!: PdfViewerComponent;
 
+
+  constructor() {
+    //For testing custom paths to pdf worker and wasm folder
+    //set them here
+    //(window as any).pdfWorkerSrc = '/pdf.worker.js';
+    //(window as any).wasmUrl = '/wasm/';
+  }
+
   ngOnInit() {
     if (window.screen.width <= 768) {
       this.mobile = true;
@@ -69,6 +77,13 @@ export class AppComponent implements OnInit {
    */
   setCustomWorkerPath() {
     (window as any).pdfWorkerSrc = '/lib/pdfjs-dist/build/pdf.worker.js';
+  }
+
+  /**
+   * Set custom path to wasm folder
+   */
+  setCustomWasmPath() {
+    (window as any).wasmUrl = '/lib/pdfjs-dist/wasm/';
   }
 
   incrementPage(amount: number) {

--- a/src/app/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/pdf-viewer/pdf-viewer.component.ts
@@ -256,7 +256,7 @@ export class PdfViewerComponent
       pdfWorkerSrc = (window as any).pdfWorkerSrc;
     } else {
       pdfWorkerSrc = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfJsVersion
-        }/legacy/build/pdf.worker.min.mjs`;
+      }/legacy/build/pdf.worker.min.mjs`;
     }
 
     assign(GlobalWorkerOptions, 'workerSrc', pdfWorkerSrc);
@@ -483,12 +483,22 @@ export class PdfViewerComponent
     if (!this._cMapsUrl) {
       return this.src;
     }
-
+   
     const params: any = {
       cMapUrl: this._cMapsUrl,
       cMapPacked: true,
       enableXfa: true,
     };
+
+    const pdfJsVersion: string = (PDFJS as any).version;
+    if ((window as any).wasmUrl) {
+      params.wasmUrl = (window as any).wasmUrl;
+    }
+    else{
+      params.wasmUrl = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfJsVersion
+      }/wasm/`;
+    }
+    
     params.isEvalSupported = false; // http://cve.org/CVERecord?id=CVE-2024-4367
 
     if (srcType === 'string') {


### PR DESCRIPTION
By default, gets from CDN
Set custom path similarly to pdfWorkerSrc

@VadimDez if this isn't useful to you, just close it. I needed this for a project of mine.

Enables pdfjs-dist 5.4.0 support and allows use of WASM for JPEG2000 rendering. Uses CDN as default, but the user can still set a custom URL (like with pdfWorkerSrc) by setting (window as any).wasmUrl.